### PR TITLE
Simplify flow

### DIFF
--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "trailingComma": "none",
   "jsxBracketSameLine": true,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
 }

--- a/client/src/pages/Login/index.js
+++ b/client/src/pages/Login/index.js
@@ -35,11 +35,7 @@ const Login = () => {
 
   const handleUserInit = useCallback(
     resp => {
-      if (resp.status === 201) {
-        notifySuccess(
-          'We successfully created your account in our database. You can now login to the app.'
-        );
-      } else {
+      if (resp.ok) {
         setUser(resp.data);
         history.push(HOME_URL);
       }

--- a/client/src/pages/Login/index.js
+++ b/client/src/pages/Login/index.js
@@ -5,7 +5,7 @@ import { GoogleLogin } from 'react-google-login';
 import GoogleButton from 'react-google-button';
 
 import { HOME_URL } from 'config/urls';
-import { notifyError, notifySuccess } from 'utils/notifications';
+import { notifyError } from 'utils/notifications';
 import { UserContext, GithubStars, Layout } from 'components';
 
 import { userInit } from './sdk';
@@ -21,14 +21,9 @@ const Login = () => {
     const queryParams = new URLSearchParams(history.location.search);
 
     const error = queryParams.get('error');
-    const message = queryParams.get('message');
 
     if (error) {
       notifyError(error);
-      history.replace({ search: null });
-    }
-    if (message) {
-      notifySuccess(message);
       history.replace({ search: null });
     }
   }, [history]);

--- a/client/src/pages/Login/index.js
+++ b/client/src/pages/Login/index.js
@@ -33,6 +33,8 @@ const Login = () => {
       if (resp.ok) {
         setUser(resp.data);
         history.push(HOME_URL);
+      } else {
+        notifyError(resp.data[0]);
       }
     },
     [history, setUser]
@@ -41,14 +43,13 @@ const Login = () => {
   const onGoogleLoginSuccess = useCallback(
     response => {
       const profileData = {
+        access_token: response.accessToken,
         email: response.profileObj.email,
         first_name: response.profileObj.givenName,
         last_name: response.profileObj.familyName
       };
 
-      userInit(profileData)
-        .then(handleUserInit)
-        .catch(notifyError);
+      userInit(profileData).then(handleUserInit).catch(notifyError);
     },
     [handleUserInit]
   );

--- a/client/src/pages/Login/sdk.js
+++ b/client/src/pages/Login/sdk.js
@@ -1,3 +1,3 @@
 import { post } from 'utils/sdk';
 
-export const userInit = (data) => post('users/init/', data);
+export const userInit = data => post('users/init/', data);

--- a/client/src/utils/notifications.js
+++ b/client/src/utils/notifications.js
@@ -4,7 +4,3 @@ export const notifyError = (error, options) => {
   error = error || 'Something went wrong.';
   toast.error(error.toString(), options);
 };
-
-export const notifySuccess = (msg, options) => {
-  toast.success(msg, options);
-};

--- a/client/src/utils/sdk.js
+++ b/client/src/utils/sdk.js
@@ -26,7 +26,7 @@ const serializeResponse = response => {
     .then(text => {
       return text ? JSON.parse(text) : {};
     })
-    .then(data => ({ status: response.status, data }));
+    .then(data => ({ status: response.status, ok: response.ok, data }));
 };
 
 export const get = (url, options) =>

--- a/server/auth/apis.py
+++ b/server/auth/apis.py
@@ -64,17 +64,9 @@ class GoogleLoginApi(PublicApiMixin, ApiErrorsMixin, APIView):
             'last_name': user_data.get('familyName', ''),
         }
 
-        user, created = user_get_or_create(**profile_data)
-
-        if created:
-            # Note: This is just for the sake of the example.
-            # You can directly log-in your users if you want to. :)
-            message = (
-                'We successfully created your account in our database. '
-                'You can now login to the app.'
-            )
-            params = urlencode({'message': message})
-            return redirect(f'{login_url}?{params}')
+        # We use get-or-create logic here for the sake of the example.
+        # We don't have a sign-up flow.
+        user, _ = user_get_or_create(**profile_data)
 
         response = redirect(settings.BASE_FRONTEND_URL)
         jwt_cookie_data = jwt_login(user=user)

--- a/server/auth/services.py
+++ b/server/auth/services.py
@@ -12,8 +12,9 @@ from users.models import User
 from users.services import user_record_login
 
 
-GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
-GOOGLE_USER_INFO_URL = 'https://www.googleapis.com/oauth2/v1/userinfo'
+GOOGLE_TOKEN_OBTAIN_URL = 'https://oauth2.googleapis.com/token'
+GOOGLE_TOKEN_INFO_URL = 'https://www.googleapis.com/oauth2/v3/tokeninfo'
+GOOGLE_USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
 
 
 def jwt_login(user: User) -> Optional[dict]:
@@ -23,14 +24,18 @@ def jwt_login(user: User) -> Optional[dict]:
     if api_settings.JWT_AUTH_COOKIE:
         expiration = get_now().utcnow() + api_settings.JWT_EXPIRATION_DELTA
 
+        is_production_env = settings.PRODUCTION_SETTINGS
+
         cookie_data = {
             'key': api_settings.JWT_AUTH_COOKIE,
             'value': token,
             'expires': expiration,
             'httponly': True,
-            'secure': settings.PRODUCTION_SETTINGS,
-            'samesite': 'None'
+            'secure': is_production_env
         }
+
+        if is_production_env:
+            cookie_data['samesite'] = None
 
         user_record_login(user=user)
 
@@ -46,7 +51,7 @@ def google_get_access_token(*, code: str, redirect_uri: str) -> str:
         'grant_type': 'authorization_code'
     }
 
-    response = requests.post(GOOGLE_TOKEN_URL, data=data)
+    response = requests.post(GOOGLE_TOKEN_OBTAIN_URL, data=data)
 
     if not response.ok:
         raise ValidationError('Failed to obtain access token from Google')
@@ -54,6 +59,18 @@ def google_get_access_token(*, code: str, redirect_uri: str) -> str:
     access_token = response.json()['access_token']
 
     return access_token
+
+
+def google_validate_access_token(*, access_token: str) -> Optional[bool]:
+    response = requests.get(
+        GOOGLE_TOKEN_INFO_URL,
+        params={'access_token': access_token}
+    )
+
+    if not response.ok:
+        raise ValidationError('Access token is invalid')
+
+    return True
 
 
 def google_get_user_info(*, access_token: str) -> Dict[str, Any]:

--- a/server/users/apis.py
+++ b/server/users/apis.py
@@ -27,8 +27,9 @@ class UserInitApi(PublicApiMixin, ApiErrorsMixin, APIView):
 
         user, created = user_get_or_create(**serializer.validated_data)
 
-        if created:
-            return Response(status=status.HTTP_201_CREATED)
+        # We use get-or-create logic here for the sake of the example.
+        # We don't have a sign-up flow.
+        user, _ = user_get_or_create(**serializer.validated_data)
 
         response = Response(data=user_get_me(user=user))
         jwt_cookie_data = jwt_login(user=user)

--- a/server/users/apis.py
+++ b/server/users/apis.py
@@ -1,10 +1,10 @@
+from rest_framework import serializers
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import serializers, status
 
 from api.mixins import ApiErrorsMixin, ApiAuthMixin, PublicApiMixin
 
-from auth.services import jwt_login
+from auth.services import jwt_login, google_validate_access_token
 
 from users.services import user_get_or_create
 from users.selectors import user_get_me
@@ -17,6 +17,7 @@ class UserMeApi(ApiAuthMixin, ApiErrorsMixin, APIView):
 
 class UserInitApi(PublicApiMixin, ApiErrorsMixin, APIView):
     class InputSerializer(serializers.Serializer):
+        access_token = serializers.CharField()
         email = serializers.EmailField()
         first_name = serializers.CharField(required=False, default='')
         last_name = serializers.CharField(required=False, default='')
@@ -25,7 +26,8 @@ class UserInitApi(PublicApiMixin, ApiErrorsMixin, APIView):
         serializer = self.InputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        user, created = user_get_or_create(**serializer.validated_data)
+        access_token = serializer.validated_data.pop('access_token')
+        google_validate_access_token(access_token=access_token)
 
         # We use get-or-create logic here for the sake of the example.
         # We don't have a sign-up flow.


### PR DESCRIPTION
* Set `arrowParens: "avoid"` Prettier rule so that we have a consistent JS code. Reference: https://prettier.io/docs/en/options.html#arrow-function-parentheses
* Remove `if created: show a message on FE` logic. This simplifies the flow a lot.
* Attach [`Response.ok` from the `fetch` object.](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) so that we handle `4xx` errors correctly. The `catch` clause does not actually **catch** them 😉 
* Remove the `notifySuccess` util. We do not use it anywhere now.
* Add a layer of authentication for the `UserInitApi`. Now it expects `access_token` to be sent. This access token gets validated with the newly introduced `google_validate_access_token` service. This prevents malicious calls to this API, since it is public.
* Attach `samesite: None` to the JWT cookie **only in production environments**. While developing locally, BE & FE are on the same domain - `localhost`.