### PR TITLE
Prevent possible runtime errors

### DIFF
--- a/client/src/pages/Login/index.js
+++ b/client/src/pages/Login/index.js
@@ -58,6 +58,10 @@ const Login = () => {
 
   const openGoogleLoginPage = useCallback(() => {
     const googleAuthUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
+    
+    // Note that the trailing slash in the redirect uri below should be removed
+    // if the authorized redirect uri in the Google console doesn't contain a trailing slash
+    // otherwise redirection to the uri will fail with a 400 redirect_uri mismatch error
     const redirectUri = 'api/v1/auth/login/google/';
 
     const scope = [

--- a/server/api/urls.py
+++ b/server/api/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 
+app_name = 'api'
 
 v1_patterns = [
     path('auth/', include(('auth.urls', 'auth'))),

--- a/server/auth/apis.py
+++ b/server/auth/apis.py
@@ -51,6 +51,12 @@ class GoogleLoginApi(PublicApiMixin, ApiErrorsMixin, APIView):
 
         domain = settings.BASE_BACKEND_URL
         api_uri = reverse('api:v1:auth:login-with-google')
+        
+        # Note that this redirect_uri has a trailing slash coming from api_uri above, 
+        # if your authorized redirect uri in google console does not have a trailing slash,
+        # you can remove the one in api_uri above by replacing api_uri definition above with:
+        # api_uri = reverse('api:v1:auth:login-with-google')[:-1], 
+        # otherwise you'll get a 400 redirect_uri mismatch error while trying to get the access token
         redirect_uri = f'{domain}{api_uri}'
 
         access_token = google_get_access_token(code=code, redirect_uri=redirect_uri)

--- a/server/auth/apis.py
+++ b/server/auth/apis.py
@@ -59,8 +59,8 @@ class GoogleLoginApi(PublicApiMixin, ApiErrorsMixin, APIView):
 
         profile_data = {
             'email': user_data['email'],
-            'first_name': user_data.get('givenName', ''),
-            'last_name': user_data.get('familyName', ''),
+            'first_name': user_data.get('given_name', ''),
+            'last_name': user_data.get('family_name', ''),
         }
 
         # We use get-or-create logic here for the sake of the example.

--- a/server/users/models.py
+++ b/server/users/models.py
@@ -10,7 +10,7 @@ class User(AbstractUser):
     secret_key = models.CharField(max_length=255, default=get_random_secret_key)
 
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = []
+    REQUIRED_FIELDS = ['username']
 
     class Meta:
         swappable = 'AUTH_USER_MODEL'

--- a/server/users/selectors.py
+++ b/server/users/selectors.py
@@ -9,8 +9,9 @@ def user_get_me(*, user: User):
     }
 
 
-def jwt_response_payload_handler(token, user=None, request=None):
+def jwt_response_payload_handler(token, user=None, request=None, issued_at=None):
     return {
         'token': token,
         'me': user_get_me(user=user),
+        'issued_at': issued_at
     }


### PR DESCRIPTION
- Renamed `givenName` and `familyName` variables to `given_name` and `family_name` to ensure `profile_data` is properly obtained from `user_data` as the user info endpoint (https://www.googleapis.com/oauth2/v3/userinfo)returns `given_name` and `family_name` instead of the former.
-  `app_name` variable in `api/urls.py` helps prevent `NoReverseMatchError` in GoogleLoginApi while reverse function to get api_uri from urls namespaces. This can also be fixed by replacing the second url pattern in `config/urls.py` with `path('api/', include(('api.urls', 'api'), namespace='api')),`
- `redirect_uri mismatch` errors can easily arise from trailing slashes being the subtle difference between the authorized redirect URIs in the Google console and the `redirect_uri` value used in the codebase. A quick warning on this can save someone hours of debugging.
- Adding username to `REQUIRED_FIELDS` in `users/models.py` helps to prevent a TypeError from a missing required positional argument (`username`) in the create_superuser function in the `UserManager`. This makes it possible to create superusers for testing purposes
- Added `issued_at’ as the fourth argument of `jwt_response_payload_handler` to fix `TypeError` as a result of excessive arguments (4) coming from https://github.com/Styria-Digital/django-rest-framework-jwt/blob/master/src/rest_framework_jwt/views.py#L34 instead of expected three(3) arguments of the function. This error prevents the traditional email-password login flow from happening successfully.